### PR TITLE
bugfix unreachable @count when Doubly is initialized with an array

### DIFF
--- a/lib/linked_list_sourav.rb
+++ b/lib/linked_list_sourav.rb
@@ -142,13 +142,13 @@ class LinkedList
 
   class Doubly < Singly
     def initialize(data) # intializes
+      @count = 1
       if data.respond_to? :each
         @head = DoublyNode.new(data[0])
         data.each.with_index { |datum, index| self.add(datum) if index > 0}
       else
         @head = DoublyNode.new(data)
       end
-      @count = 1
       self
     end
 


### PR DESCRIPTION
The bug happens when `self.add` inside the `each.with_index` block is called first before reaching `@count = 1` of code. Simply moving the `@count` helps fix this small error. 

``` ruby
require "linked_list_sourav"
 => true 
$ > list = LinkedList::Doubly.new [1, 2, 3]
nil
NoMethodError: undefined method `+' for nil:NilClass
    from .../.rvm/gems/ruby-2.3.0/gems/linked_list_sourav-0.0.14/lib/linked_list_sourav.rb:162:in `add'
    from ../.rvm/gems/ruby-2.3.0/gems/linked_list_sourav-0.0.14/lib/linked_list_sourav.rb:147:in `block in initialize'
    from ../.rvm/gems/ruby-2.3.0/gems/linked_list_sourav-0.0.14/lib/linked_list_sourav.rb:147:in `each'
    from ../.rvm/gems/ruby-2.3.0/gems/linked_list_sourav-0.0.14/lib/linked_list_sourav.rb:147:in `with_index'
    from ../.rvm/gems/ruby-2.3.0/gems/linked_list_sourav-0.0.14/lib/linked_list_sourav.rb:147:in `initialize'
    from (irb):2:in `new'
    from (irb):2
    from ../.rvm/rubies/ruby-2.3.0/bin/irb:11:in `<main>'
```
